### PR TITLE
Refs #8777: Remove configuration directories to allow package control.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,13 +6,6 @@ class candlepin::config {
     groups => $candlepin::user_groups,
   }
 
-  file { '/etc/candlepin':
-    ensure => directory,
-    mode   => '0775',
-    owner  => 'root',
-    group  => 'tomcat',
-  }
-
   concat{$::candlepin::candlepin_conf_file:
     mode  => '0600',
     owner => 'tomcat',
@@ -24,47 +17,12 @@ class candlepin::config {
     content => template('candlepin/candlepin.conf.erb'),
   }
 
-  file { "/etc/${candlepin::tomcat}":
-    ensure => directory,
-    mode   => '0775',
-    owner  => 'root',
-    group  => 'tomcat',
-  }
-
   file { "/etc/${candlepin::tomcat}/server.xml":
     ensure  => file,
     content => template("candlepin/${candlepin::tomcat}/server.xml.erb"),
     mode    => '0644',
     owner   => 'root',
     group   => 'root',
-  }
-
-  file { '/var/log/candlepin':
-    ensure => directory,
-    mode   => '0775',
-    owner  => 'tomcat',
-    group  => 'tomcat',
-  }
-
-  file { "/var/log/${candlepin::tomcat}":
-    ensure => directory,
-    mode   => '0775',
-    owner  => 'root',
-    group  => 'tomcat',
-  }
-
-  file { "/var/lib/${candlepin::tomcat}":
-    ensure => directory,
-    mode   => '0775',
-    owner  => 'tomcat',
-    group  => 'tomcat',
-  }
-
-  file { "/var/cache/${candlepin::tomcat}":
-    ensure => directory,
-    mode   => '0775',
-    owner  => 'tomcat',
-    group  => 'tomcat',
   }
 
 }

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -45,7 +45,7 @@ class candlepin::database::postgresql{
       refreshonly => true,
       before      => Service[$candlepin::tomcat],
       require     => [
-        File[$candlepin::log_dir],
+        Package['candlepin'],
         File['/etc/candlepin/candlepin.conf']
       ],
     }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -12,8 +12,8 @@ class candlepin::service{
   if $candlepin::run_init == true {
     exec { 'cpinit':
       # tomcat startup is slow - try multiple times (the initialization service is idempotent)
-      command => "/usr/bin/wget --timeout=30 --tries=5 --retry-connrefused -qO- http://localhost:8080/candlepin/admin/init >${candlepin::log_dir}/cpinit.log 2>&1 && touch /var/lib/candlepin/cpinit_done",
-      require => [Package['wget'], Service[$candlepin::tomcat], File[$candlepin::log_dir]],
+      command => '/usr/bin/wget --timeout=30 --tries=5 --retry-connrefused -qO- http://localhost:8080/candlepin/admin/init > /var/log/candlepin/cpinit.log 2>&1 && touch /var/lib/candlepin/cpinit_done',
+      require => [Package['wget'], Service[$candlepin::tomcat]],
       creates => '/var/lib/candlepin/cpinit_done'
     }
   }


### PR DESCRIPTION
This is so that the base directories are setup by the RPM and thus
have the intended permissions and settings. This fixes issues such
as logrotate failing due to incorrect permissions settings.