### PR TITLE
fixes #8777 - use correct group ownership for /v/l/candlepin

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -43,7 +43,7 @@ class candlepin::config {
     ensure => directory,
     mode   => '0775',
     owner  => 'tomcat',
-    group  => 'tomcat',
+    group  => 'root',
   }
 
   file { "/var/log/${candlepin::tomcat}":


### PR DESCRIPTION
this did not match what the candlepin-tomcat rpm was laying down
and logrotate did not like it either