### PR TITLE
Fixes #11160 : Increase the number of times the scripts attempts to c…

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -12,7 +12,7 @@ class candlepin::service{
   if $candlepin::run_init == true {
     exec { 'cpinit':
       # tomcat startup is slow - try multiple times (the initialization service is idempotent)
-      command => '/usr/bin/wget --timeout=30 --tries=20 --wait=20 --retry-connrefused -qO- http://localhost:8080/candlepin/admin/init > /var/log/candlepin/cpinit.log 2>&1 && touch /var/lib/candlepin/cpinit_done',
+      command => '/usr/bin/wget --timeout=30 --tries=40 --wait=20 --retry-connrefused -qO- http://localhost:8080/candlepin/admin/init > /var/log/candlepin/cpinit.log 2>&1 && touch /var/lib/candlepin/cpinit_done',
       require => [Package['wget'], Service[$candlepin::tomcat]],
       creates => '/var/lib/candlepin/cpinit_done',
     }


### PR DESCRIPTION
…all cpinit before failing.

The prevailing thought is that this is due to lack of entropy on vms. If that is trye, all that can be done
is wait longer. This bumps up the script to attempt to connect 40 times, waiting 20 seconds between attempts.
This should give 800 seconds for the machine to get entropy