### PR TITLE
add flag to manage wget

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,10 @@
 # $ca_key_password::              CA key password
 #
 # $version::                      Version of Candlepin to install
+#                                 Defaults to installed
+#
+# $wget_version::                 Passed to the wget package.
+#                                 Defaults to installed
 #
 # $run_init::                     Boolean indicating if the init api should be called on Candlepin
 #
@@ -89,7 +93,6 @@
 # $ssl_port::                     Port to deploy SSL enabled Tomcat server on
 #
 class candlepin (
-
   $manage_db   = $candlepin::params::manage_db,
   $db_type     = $candlepin::params::db_type,
   $db_host     = $candlepin::params::db_host,
@@ -129,6 +132,7 @@ class candlepin (
   $qpid_ssl_port = $candlepin::params::qpid_ssl_port,
 
   $version = $candlepin::params::version,
+  $wget_version = $candlepin::params::wget_version,
   $run_init = $candlepin::params::run_init,
   $adapter_module = $candlepin::params::adapter_module,
   $amq_enable = $candlepin::params::amq_enable,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,10 +1,8 @@
 # Candlepin installation packages
 class candlepin::install {
-
   package { ['candlepin', "candlepin-${candlepin::tomcat}"]:
     ensure => $candlepin::version,
   }
 
-  ensure_packages(['wget'])
-
+  ensure_packages(['wget'], { ensure => $candlepin::wget_version, })
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,5 @@
 # Candlepin params
 class candlepin::params {
-
   $tomcat = $::osfamily ? {
     /^(RedHat|Linux)/ => $::operatingsystem ? {
       'Fedora'  => 'tomcat',
@@ -24,7 +23,7 @@ class candlepin::params {
   # this comes from keystore
   $db_password = cache_data('foreman_cache_data', 'candlepin_db_password', random_password(32))
   $keystore_password = undef
-  
+
   $amq_enable = false
   $amqp_keystore_password = undef
   $amqp_truststore_password = undef
@@ -56,6 +55,7 @@ class candlepin::params {
   $qpid_ssl_port = 5671
 
   $version = 'installed'
+  $wget_version = 'installed'
   $run_init = true
   $adapter_module = undef
   $enable_hbm2ddl_validate = true


### PR DESCRIPTION
I'm, not sure why wget is needed in this module, but I added a flag to decide if it should manage wget or not.

Simply using ensure_packages is not enough, as (at least in our case) the user could manage the package someplace else and use ensure => latest as a parameter.