### PR TITLE
Fixes #13361: tell puppet to wait for wget to finish

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -15,6 +15,8 @@ class candlepin::service{
       command => '/usr/bin/wget --no-proxy --timeout=30 --tries=40 --wait=20 --retry-connrefused -qO- http://localhost:8080/candlepin/admin/init > /var/log/candlepin/cpinit.log 2>&1 && touch /var/lib/candlepin/cpinit_done',
       require => [Package['wget'], Service[$candlepin::tomcat]],
       creates => '/var/lib/candlepin/cpinit_done',
+      # timeout is roughly "wait" * "tries" from above
+      timeout =>  800,
     }
   }
 


### PR DESCRIPTION
The wget timeout was previously set to 13.33 minutes. However, puppet was not
aware that this command could take longer than 5 minutes, and would kill the
wget before candlepin was finished starting up. This results in a failed run of `katello-installer`.

I've seen 7 to 8 minutes for startup in some cases, depending on the
performance of the system.