### PR TITLE
Librarian-puppet errors resolving dependencies for puppet concat

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs-concat",
-      "version_requirement": ">= 1.0.0 < 3.0.0"
+      "version_requirement": ">= 1.0.0 < 2.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
Errors trying to install this module with librarian:

```
 Module puppetlabs-apt found versions: 2.2.1, 2.2.0, 2.1.1, 2.1.0, 2.0.1, 2.0.0, 1.8.0, 1.7.0, 1.6.0, 1.5.2, 1.5.1, 1.5.0, 1.4.2, 1.4.0, 1.3.0, 1.2.0, 1.1.1, 1.1.0, 1.0.1, 1.0.0, 0.0.4, 0.0.3
[Librarian]     Checking puppetlabs-apt/2.2.1 <https://forgeapi.puppetlabs.com>
[Librarian]       Resolved puppetlabs-apt (< 3.0.0, >= 1.8.0) <(no source specified)> at puppetlabs-apt/2.2.1 <https://forgeapi.puppetlabs.com>
[Librarian]   Resolved puppetlabs-apt (< 3.0.0, >= 1.8.0) <(no source specified)>
[Librarian] Conflict between puppetlabs-concat (< 2.0.0, >= 1.1.0) <(no source specified)> and puppetlabs-concat/2.1.0 <https://forgeapi.puppetlabs.com>
```