### PR TITLE
Manage Tomcat trustore

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,7 +55,15 @@
 #
 # $thumbslug_oauth_secret::       The oauth secret for talking to Thumbslug
 #
+# $keystore_file::                Tomcat keystore file to use
+#
 # $keystore_password::            Password for keystore being used with Tomcat
+#
+# $keystore_type::                Keystore type
+#
+# $truststore_file::              Tomcat truststore file to use
+#
+# $truststore_password::          Password for truststore being used with Tomcat
 #
 # $ca_key::                       CA key file to use
 #
@@ -120,7 +128,12 @@ class candlepin (
   $thumbslug_oauth_key = $candlepin::params::thumbslug_oauth_key,
   $thumbslug_oauth_secret = $candlepin::params::thumbslug_oauth_secret,
 
+  $keystore_file = $candlepin::params::keystore_file,
   $keystore_password = $candlepin::params::keystore_password,
+  $keystore_type = $candlepin::params::keystore_type,
+  $truststore_file = $candlepin::params::truststore_file,
+  $truststore_password = $candlepin::params::truststore_password,
+
   $amqp_keystore = $candlepin::params::amqp_keystore,
   $amqp_keystore_password = $candlepin::params::amqp_keystore_password,
   $amqp_truststore = $candlepin::params::amqp_truststore,
@@ -157,6 +170,12 @@ class candlepin (
 
   validate_absolute_path($ca_key)
   validate_absolute_path($ca_cert)
+  if $keystore_password {
+    validate_string($keystore_password)
+  }
+  if $truststore_password {
+    validate_string($truststore_password)
+  }
 
   $weburl = "https://${::fqdn}/${candlepin::deployment_url}/distributors?uuid="
   $apiurl = "https://${::fqdn}/${candlepin::deployment_url}/api/distributors/"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,12 @@ class candlepin::params {
 
   # this comes from keystore
   $db_password = cache_data('foreman_cache_data', 'candlepin_db_password', random_password(32))
+
+  $keystore_file = 'conf/keystore'
   $keystore_password = undef
+  $keystore_type = 'PKCS12'
+  $truststore_file = 'conf/keystore'
+  $truststore_password = undef
 
   $amq_enable = false
   $amqp_keystore_password = undef

--- a/templates/candlepin.conf.erb
+++ b/templates/candlepin.conf.erb
@@ -1,7 +1,7 @@
 ### File managed with puppet ###
 ## Module: '<%= scope.to_hash['module_name'] %>'
 
-<% unless [nil, :undefined, :undef].include?(scope.lookupvar("candlepin::consumer_system_name_pattern")) -%>
+<% unless [nil, :undefined, :undef].include?(scope['candlepin::consumer_system_name_pattern']) -%>
 candlepin.consumer_system_name_pattern=<%= @consumer_system_name_pattern %>
 <%- end -%>
 candlepin.environment_content_filtering=<%= scope['candlepin::env_filtering_enabled'] %>
@@ -23,13 +23,13 @@ candlepin.auth.oauth.enable=true
 candlepin.auth.oauth.consumer.<%= scope['candlepin::oauth_key'] %>.secret=<%= scope['candlepin::oauth_secret'] %>
 <%- end -%>
 
-<% unless [nil, :undefined, :undef].include?(scope.lookupvar("candlepin::adapter_module")) -%>
+<% unless [nil, :undefined, :undef].include?(scope['candlepin::adapter_module']) -%>
 module.config.adapter_module=<%= scope['candlepin::adapter_module'] %>
 <%- end -%>
 
 candlepin.ca_key=<%= scope['candlepin::ca_key'] %>
 candlepin.ca_cert=<%= scope['candlepin::ca_cert'] %>
 candlepin.crl.file=<%= scope['candlepin::crl_file'] %>
-<% unless [nil, :undefined, :undef].include?(scope.lookupvar("candlepin::ca_key_password")) -%>
+<% unless [nil, :undefined, :undef].include?(scope['candlepin::ca_key_password']) -%>
 candlepin.ca_key_password=<%= scope['candlepin::ca_key_password'] %>
 <%- end -%>

--- a/templates/tomcat/server.xml.erb
+++ b/templates/tomcat/server.xml.erb
@@ -88,10 +88,10 @@
                maxThreads="150" scheme="https" secure="true"
                clientAuth="want"
                sslProtocols="TLSv1.2,TLSv1.1,TLSv1"
-               keystoreFile="conf/keystore"
-               truststoreFile="conf/keystore"
-               keystorePass="<%= scope.lookupvar("candlepin::keystore_password") %>"
-               keystoreType="PKCS12"
+               keystoreFile="<%= scope['::candlepin::keystore_file'] %>"
+               truststoreFile="<%= scope['::candlepin::truststore_file'] %>"
+               keystorePass="<%= scope['::candlepin::keystore_password'] %>"
+               keystoreType="<%= scope['::candlepin::keystore_type'] %>"
                ciphers="SSL_RSA_WITH_3DES_EDE_CBC_SHA,
                     TLS_RSA_WITH_AES_256_CBC_SHA,
                     TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA,
@@ -100,7 +100,7 @@
                     TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,
                     TLS_ECDH_RSA_WITH_AES_256_CBC_SHA,
                     TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"
-               truststorePass="<%= scope.lookupvar("candlepin::keystore_password") %>" />
+               truststorePass="<%= scope['candlepin::truststore_password'] %>" />
 
     <!-- Define an AJP 1.3 Connector on port 8009 -->
     <Connector port="8009" protocol="AJP/1.3" redirectPort="<%= scope['::candlepin::ssl_port'] %>" />

--- a/templates/tomcat6/server.xml.erb
+++ b/templates/tomcat6/server.xml.erb
@@ -89,10 +89,10 @@
                maxThreads="150" scheme="https" secure="true"
                clientAuth="want"
                sslEnabledProtocols="TLSv1.2,TLSv1.1,TLSv1"
-               keystoreFile="conf/keystore"
-               truststoreFile="conf/keystore"
-               keystorePass="<%= scope.lookupvar("candlepin::keystore_password") %>"
-               keystoreType="PKCS12"
+               keystoreFile="<%= scope['::candlepin::keystore_file'] %>"
+               truststoreFile="<%= scope['::candlepin::truststore_file'] %>"
+               keystorePass="<%= scope['::candlepin::keystore_password'] %>"
+               keystoreType="<%= scope['::candlepin::keystore_type'] %>"
                ciphers="SSL_RSA_WITH_3DES_EDE_CBC_SHA,
                     TLS_RSA_WITH_AES_256_CBC_SHA,
                     TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA,
@@ -101,7 +101,7 @@
                     TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,
                     TLS_ECDH_RSA_WITH_AES_256_CBC_SHA,
                     TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"
-               truststorePass="<%= scope.lookupvar("candlepin::keystore_password") %>" />
+               truststorePass="<%= scope['::candlepin::truststore_password'] %>" />
 
     <!-- Define an AJP 1.3 Connector on port 8009 -->
     <Connector port="8009" protocol="AJP/1.3" redirectPort="<%= scope['::candlepin::ssl_port'] %>" />


### PR DESCRIPTION
I managed to complettly broke the other PR for this issue, so here it is again: add the possibility to also manage the truststore and the keystore type.