### PR TITLE
Fixes #13530 - change ensure defaults from installed to present

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,10 +64,10 @@
 # $ca_key_password::              CA key password
 #
 # $version::                      Version of Candlepin to install
-#                                 Defaults to installed
+#                                 Defaults to present
 #
 # $wget_version::                 Passed to the wget package.
-#                                 Defaults to installed
+#                                 Defaults to present
 #
 # $run_init::                     Boolean indicating if the init api should be called on Candlepin
 #
@@ -82,7 +82,7 @@
 # $amqp_truststore::              Location of the amqp truststore to use
 #
 # $amqp_truststore_password::     Password for the amqp trusture
-# 
+#
 # $consumer_system_name_pattern:: Regex that consistutes a valid consumer name
 #
 # $enable_hbm2ddl_validate::      Boolean that if true will perform a schema check to ensure compliance

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -54,8 +54,8 @@ class candlepin::params {
 
   $qpid_ssl_port = 5671
 
-  $version = 'installed'
-  $wget_version = 'installed'
+  $version = 'present'
+  $wget_version = 'present'
   $run_init = true
   $adapter_module = undef
   $enable_hbm2ddl_validate = true

--- a/spec/classes/candlepin_install_spec.rb
+++ b/spec/classes/candlepin_install_spec.rb
@@ -17,8 +17,8 @@ describe 'candlepin::install' do
       "class {'candlepin':}"
     end
 
-    it { should contain_package('candlepin').with('ensure' => 'installed') }
-    it { should contain_package('candlepin-tomcat6').with('ensure' => 'installed') }
+    it { should contain_package('candlepin').with('ensure' => 'present') }
+    it { should contain_package('candlepin-tomcat6').with('ensure' => 'present') }
   end
 
   context 'on el7' do
@@ -36,7 +36,7 @@ describe 'candlepin::install' do
       "class {'candlepin':}"
     end
 
-    it { should contain_package('candlepin').with('ensure' => 'installed') }
-    it { should contain_package('candlepin-tomcat').with('ensure' => 'installed') }
+    it { should contain_package('candlepin').with('ensure' => 'present') }
+    it { should contain_package('candlepin-tomcat').with('ensure' => 'present') }
   end
 end

--- a/spec/classes/candlepin_spec.rb
+++ b/spec/classes/candlepin_spec.rb
@@ -17,7 +17,6 @@ describe 'candlepin' do
     it { should contain_class('candlepin::config') }
     it { should contain_class('candlepin::database') }
     it { should contain_class('candlepin::service') }
-    it { should contain_file('/etc/candlepin/candlepin.conf') }
     it { should contain_service('tomcat6').with_ensure('running') }
 
 
@@ -38,7 +37,6 @@ describe 'candlepin' do
     it { should contain_class('candlepin::config') }
     it { should contain_class('candlepin::database') }
     it { should contain_class('candlepin::service') }
-    it { should contain_file('/etc/candlepin/candlepin.conf') }
     it { should contain_service('tomcat').with_ensure('running') }
   end
 


### PR DESCRIPTION
ensure_package uses ensure => 'present' as a default. puppet_candlepin uses ensure => 'installed. 
`ensure_packages(['wget'], ensure => present)` and `ensure_packages(['wget'], ensure => installed)` are evaluated as different packages and the package is declared duplicitly.