### PR TITLE
Add support for non-validated SSL on database connections.

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -10,6 +10,8 @@ class candlepin::database::postgresql(
   $db_type                 = $::candlepin::db_type,
   $db_host                 = $::candlepin::db_host,
   $db_port                 = pick($::candlepin::db_port, 5432),
+  $db_ssl                  = $::candlepin::db_ssl
+  $db_ssl_verify           = $::candlepin::db_ssl_verify
   $db_name                 = $::candlepin::db_name,
   $db_user                 = $::candlepin::db_user,
   $db_password             = $::candlepin::db_password,

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -10,8 +10,8 @@ class candlepin::database::postgresql(
   $db_type                 = $::candlepin::db_type,
   $db_host                 = $::candlepin::db_host,
   $db_port                 = pick($::candlepin::db_port, 5432),
-  $db_ssl                  = $::candlepin::db_ssl
-  $db_ssl_verify           = $::candlepin::db_ssl_verify
+  $db_ssl                  = $::candlepin::db_ssl,
+  $db_ssl_verify           = $::candlepin::db_ssl_verify,
   $db_name                 = $::candlepin::db_name,
   $db_user                 = $::candlepin::db_user,
   $db_password             = $::candlepin::db_password,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,13 @@
 #                                 from standard port of the :db_type.
 #                                 type:Optional[Integer[0, 65535]]
 #
+# $db_ssl::                       Boolean indicating if the connection to the database should be over
+#                                 an SSL connection.
+#                                 type:Boolean
+#
+# $db_ssl_verify::                Boolean indicating if the SSL connection to the database should be verified
+#                                 type:Boolean
+#
 # $db_name::                      The name of the Candlepin database
 #                                 type:String
 #
@@ -137,6 +144,8 @@ class candlepin (
   $db_type                      = $::candlepin::params::db_type,
   $db_host                      = $::candlepin::params::db_host,
   $db_port                      = $::candlepin::params::db_port,
+  $db_ssl                       = $::candlepin::params::db_ssl,
+  $db_ssl_verify                = $::candlepin::params::db_ssl_verify,
   $db_name                      = $::candlepin::params::db_name,
   $db_user                      = $::candlepin::params::db_user,
   $db_password                  = $::candlepin::params::db_password,
@@ -210,6 +219,9 @@ class candlepin (
   if $truststore_password {
     validate_string($truststore_password)
   }
+
+  validate_bool($db_ssl)
+  validate_bool($db_ssl_verify)
 
   $weburl = "https://${::fqdn}/${candlepin::deployment_url}/distributors?uuid="
   $apiurl = "https://${::fqdn}/${candlepin::deployment_url}/api/distributors/"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,8 @@ class candlepin::params {
   $db_user = 'candlepin'
   $db_name = 'candlepin'
   $db_port = undef
+  $db_ssl  = false
+  $db_ssl_verify = true
 
   # this comes from keystore
   $db_password = cache_data('foreman_cache_data', 'candlepin_db_password', random_password(32))

--- a/templates/_candlepin_database.conf.erb
+++ b/templates/_candlepin_database.conf.erb
@@ -1,6 +1,6 @@
 jpa.config.hibernate.dialect=<%= @db_dialect %>
 jpa.config.hibernate.connection.driver_class=<%= @db_driver %>
-jpa.config.hibernate.connection.url=jdbc:<%= @db_type %>://<%= @db_host %>:<%= @db_port %>/<%= @db_name %>
+jpa.config.hibernate.connection.url=jdbc:<%= @db_type %>://<%= @db_host %>:<%= @db_port %>/<%= @db_name %><% if @db_ssl %>?ssl=true<% unless @db_ssl_verify %>&sslfactory=org.postgresql.ssl.NonValidatingFactory<% end %><% end %>
 <% if @enable_hbm2ddl_validate -%>
 jpa.config.hibernate.hbm2ddl.auto=validate
 <% end -%>
@@ -15,7 +15,7 @@ org.quartz.jobStore.class=org.quartz.impl.jdbcjobstore.JobStoreTX
 org.quartz.jobStore.driverDelegateClass=<%= @db_quartz_dialect %>
 
 org.quartz.dataSource.myDS.driver=<%= @db_driver %>
-org.quartz.dataSource.myDS.URL=jdbc:<%= @db_type %>://<%= @db_host %>:<%= @db_port %>/<%= @db_name %>
+org.quartz.dataSource.myDS.URL=jdbc:<%= @db_type %>://<%= @db_host %>:<%= @db_port %>/<%= @db_name %><% if @db_ssl %>?ssl=true<% unless @db_ssl_verify %>&sslfactory=org.postgresql.ssl.NonValidatingFactory<% end %><% end %>
 org.quartz.dataSource.myDS.user=<%= @db_user %>
 org.quartz.dataSource.myDS.password=<%= @db_password %>
 org.quartz.dataSource.myDS.maxConnections=5


### PR DESCRIPTION
We are working on various changes to the default katello install, such as splitting the database off to an external host. For that, we use an SSL'ed connection.  I'd actually rather have an options of no, yes, verified but am not sure the best way to expose that.

I did not add this to the liquibase since the default local install doesnt use SSL, and it appears there might be an issue with [liquibase connecting to postgresql over SSL|https://liquibase.jira.com/browse/CORE-1281].

I'm open to other validation factories, but this seemed like the easy start.

Need to add testing. sorry.
