### PR TITLE
Contain candlepin::service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -180,12 +180,13 @@ class candlepin (
   $apiurl = "https://${::fqdn}/${candlepin::deployment_url}/api/distributors/"
   $amqpurl = "tcp://${qpid_hostname}:${qpid_ssl_port}?ssl='true'&ssl_cert_alias='amqp-client'"
 
+  contain ::candlepin::service
+
   class { '::candlepin::repo': } ->
   class { '::candlepin::install': } ~>
   class { '::candlepin::config':  } ~>
   class { "::candlepin::database::${::candlepin::db_type}": } ~>
   class { '::candlepin::qpid': } ~>
-  class { '::candlepin::service': } ~>
-  Class['candlepin']
+  Class['candlepin::service']
 
 }

--- a/spec/classes/candlepin_spec.rb
+++ b/spec/classes/candlepin_spec.rb
@@ -5,13 +5,34 @@ describe 'candlepin' do
     context "on #{os}" do
       let(:facts) { facts }
 
-      it { should compile.with_all_deps }
-      it { should contain_class('candlepin::repo') }
-      it { should contain_class('candlepin::install') }
-      it { should contain_class('candlepin::config') }
-      it { should contain_class('candlepin::database::postgresql') }
-      it { should contain_class('candlepin::service') }
-      it { should contain_service('tomcat').with_ensure('running') }
+      describe 'base class' do
+        it { should compile.with_all_deps }
+        it { should contain_class('candlepin::repo') }
+        it { should contain_class('candlepin::install') }
+        it { should contain_class('candlepin::config') }
+        it { should contain_class('candlepin::database::postgresql') }
+        it { should contain_class('candlepin::service') }
+        it { should contain_service('tomcat').with_ensure('running') }
+      end
+
+      describe 'notify' do
+        let :pre_condition do
+          <<-EOS
+          exec { 'notification':
+            command => '/bin/true',
+            notify  => Class['candlepin'],
+          }
+
+          exec { 'dependency':
+            command => '/bin/true',
+            require => Class['candlepin'],
+          }
+          EOS
+        end
+
+        it { should contain_exec('notification').that_notifies('Service[tomcat]') }
+        it { should contain_exec('dependency').that_requires(['Service[tomcat]', 'Exec[cpinit]']) }
+      end
     end
   end
 end


### PR DESCRIPTION
This should allow ```notify => Class['qpid']``` and have it restart the service or ```require => Class['qpid']``` and be sure ```Exec['cpinit']``` has completed.